### PR TITLE
Add Rails 5 support

### DIFF
--- a/lib/attachinary/orm/active_record/extension.rb
+++ b/lib/attachinary/orm/active_record/extension.rb
@@ -15,10 +15,17 @@ module Attachinary
           class_name: '::Attachinary::File',
           conditions: { scope: options[:scope].to_s },
           dependent: :destroy
+      elsif Rails::VERSION::MAJOR > 3 && Rails::VERSION::MAJOR < 5
+        has_many :"#{relation}",
+                 -> { where scope: options[:scope].to_s },
+                 as: :attachinariable,
+                 class_name: '::Attachinary::File',
+                 dependent: :destroy
       else
         has_many :"#{relation}",
           -> { where scope: options[:scope].to_s }, 
           as: :attachinariable,
+          inverse_of: :attachinariable,
           class_name: '::Attachinary::File',
           dependent: :destroy
       end


### PR DESCRIPTION
Since that belongs_to is required by default at Rails 5 we need to add the `inverse_of`option to has_many on the owner object or you will receive a validation error when you create try create it.